### PR TITLE
Fix FBS posting parsing issues

### DIFF
--- a/ozon/fbs.go
+++ b/ozon/fbs.go
@@ -191,7 +191,7 @@ type FBSPosting struct {
 	TrackingNumber string `json:"tracking_number"`
 
 	// Details on shipping rate
-	Tariffication FBSPostingTariffication `json:"tariffication"`
+	Tariffication []FBSPostingTariffication `json:"tariffication"`
 
 	// Economy product identifier
 	QuantumId int64 `json:"quantum_id"`
@@ -364,20 +364,20 @@ type FBSRequirements struct {
 	// To pack the shipment, pass the CCD number for all listed SKUs.
 	// If you do not have a CCD number, pass the value `is_gtd_absent` = true
 	// via the `/v3/posting/fbs/ship/package`
-	ProductsRequiringGTD []string `json:"products_requiring_gtd"`
+	ProductsRequiringGTD []int64 `json:"products_requiring_gtd"`
 
 	// Array of Ozon Product IDs (SKU) for which
 	// you need to pass the manufacturing country.
 	//
 	// To pack the shipment, pass the manufacturing
 	// country value for all listed SKUs via the `/v2/posting/fbs/product/country/set` method
-	ProductsRequiringCountry []string `json:"products_requiring_country"`
+	ProductsRequiringCountry []int64 `json:"products_requiring_country"`
 
 	// Array of Ozon Product IDs (SKU) for which you need to pass the "Chestny ZNAK" labeling
-	ProductsRequiringMandatoryMark []string `json:"products_requiring_mandatory_mark"`
+	ProductsRequiringMandatoryMark []int64 `json:"products_requiring_mandatory_mark"`
 
 	// Array of Ozon Product IDs (SKU) for which you need to pass a product batch registration number
-	ProductsRequiringRNPT []string `json:"products_requiring_rnpt"`
+	ProductsRequiringRNPT []int64 `json:"products_requiring_rnpt"`
 }
 
 type PostingProduct struct {

--- a/ozon/products.go
+++ b/ozon/products.go
@@ -742,9 +742,6 @@ type UpdatePricesParams struct {
 
 // Product price details
 type UpdatePricesPrice struct {
-	// Min price that ozon can count for auto promos
-	MinPriceForAutoActionsEnabled bool `json:"min_price_for_auto_actions_enabled"`
-
 	// Attribute for enabling and disabling promos auto-application
 	AutoActionEnabled string `json:"auto_action_enabled"`
 


### PR DESCRIPTION
## Summary
- correct FBS requirements fields to use numeric arrays
- accept array for posting tariffication
- clean duplicate field in price update struct

## Testing
- `go test ./...` *(fails: invalid character 'D' looking for beginning of value)*

------